### PR TITLE
Add Dockerfile and Fly.io deployment instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore any build artifacts that could interfere with the dotnet build happening
+# during Docker image creation.
+**/bin/
+**/obj/

--- a/.github/workflows/test_docker_build.yaml
+++ b/.github/workflows/test_docker_build.yaml
@@ -1,0 +1,19 @@
+name: Test Docker Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build image
+        run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+WORKDIR /source
+
+# Copy all .csproj files and use `dotnet restore` to install dependencies.
+# Doing this first will allow the dependencies to stay cached if the csproj
+# files didn't change, even if other code did.
+COPY *.sln .
+COPY **/*.csproj ./
+RUN dotnet sln list \
+    | tail -n +3 \
+    | xargs -I {} sh -c \
+        'target="{}"; dir="${target%/*}"; file="${target##*/}"; mkdir -p -- "$dir"; mv -- "$file" "$target"'
+RUN dotnet restore
+
+# Copy the code over and build the application.
+COPY . .
+RUN dotnet publish Server -c Release -o /app --no-restore
+
+# Build runtime image.
+FROM mcr.microsoft.com/dotnet/runtime:6.0
+WORKDIR /app
+COPY --from=build-env /app .
+ENTRYPOINT ["dotnet", "Server.dll"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ chmod +x filepath to the server executable
 systemctl enable --now smo.service
 ```
 
+## Running with Docker
+
+A Dockerfile is included if you want to run the server without installing `dotnet`, or if you are using a hosting
+environment with Docker support. See [deploy_to_fly_io.md](https://github.com/Sanae6/SmoOnlineServer/blob/master/docs/deploy_to_fly_io.md)
+for an easy way to run a server using the [Fly.io](https://www.fly.io) free tier.
+
 ## Commands
 
 Run `help` to get what commands are available in the server console.

--- a/docs/deploy_to_fly_io.md
+++ b/docs/deploy_to_fly_io.md
@@ -1,0 +1,65 @@
+# Deploy to Fly.io
+
+## What is Fly.io?
+
+[Fly.io](https://www.fly.io) is a platform for running applications in the cloud. Their tooling builds
+an image from a Dockerfile and runs it in a datacenter without you having to manage the server yourself.
+They have a free tier that provides more than enough power to run the SMO Online server code.
+
+Note: Fly *does* require a credit card on signup, but this is only to prevent bots from abusing their free tier. The setup listed in this guide is completely covered by their free tier, so you should not incur any charges.
+
+## Deployment Instructions
+
+1. First, follow Fly's [Installing flyctl](https://fly.io/docs/getting-started/installing-flyctl/) and
+[Log in](https://fly.io/docs/getting-started/log-in-to-fly/) instructions to get your computer set up
+to interact with Fly.
+    * `flyctl` is Fly's tool for creating and deploying applications.
+2. Clone this repo using `git clone https://github.com/Sanae6/SmoOnlineServer.git` in your terminal.
+3. Run `cd SmoOnlineServer` to enter the repo directory.
+4. Run `flyctl launch`.
+    * This is the command for creating a new application on Fly. It will ask for a name to use (must be globally unique) and a region
+    to deploy to, you should pick a region close to you if it did not pick one automatically.
+    * This command generates a `fly.toml` file in the repo, which is the configuration that Fly looks at when
+    deciding how to run your application.
+5. By default this `fly.toml` file assumes that you are deploying a standard HTTP application, but this server operates over raw TCP. You will need to edit this file to look like the following:
+    *   ```toml
+        app = "<your-app-name>"
+        kill_signal = "SIGINT"
+        kill_timeout = 5
+        processes = []
+
+        [env]
+
+        [experimental]
+          allowed_public_ports = []
+          auto_rollback = true
+
+        [[services]]
+          http_checks = []
+          internal_port = 1027
+          processes = ["app"]
+          protocol = "tcp"
+          script_checks = []
+  
+          [services.concurrency]
+            hard_limit = 25
+            soft_limit = 20
+            type = "connections"
+
+          [[services.ports]]
+            port = 1027
+        ```
+    * This configuration tells Fly that you are running the app over plain TCP, not HTTP, and to expose
+    port 1027 instead of ports 80 and 443 like the default configuration will.
+6. Run `flyctl deploy`.
+    * This will build the server code into a Docker image and push it to Fly, where it will then run in
+    their datacenter in the region that you chose. This step might take a few minutes to complete.
+7. Now that your app is running, you can log in to Fly in your browser. Under your [Apps](https://fly.io/dashboard/personal)
+page you should see the application, and clicking on it will bring you to the Overview page.
+    * The most important thing here is the "IP addresses" box near the middle of the page. When you start the
+    modded game, this IP will be the one you want to enter (use the one with "v4" next to it).
+    * Another useful page is the Monitoring page on the left, which will show you useful logs about when users
+    connect, when moons are picked up, etc.
+
+And that's it! If you've made it this far, you should have the server up and running for free. By default Fly allocates
+one CPU core and 256MB of RAM for their free tier, which should be plenty.


### PR DESCRIPTION
Adds a Dockerfile and instructions for deploying to the free tier of Fly.io for anybody who wants to run the server but isn't familiar with the operations-side of software development.

I saw that #6 also adds a Dockerfile, but that PR seems more focused on 1. pushing an image to an external registry 2. running that pushed image locally. This PR is intended for people who maybe aren't comfortable or knowledgable about provisioning their own server and setting everything up manually, but could follow the doc I've added to run the server for free on a platform that will keep it running automatically and give easy access to server logs. There definitely is some overlap between this PR and #6 though, so feel free to combine this with that one or close this if it's out of scope.