### PR TITLE
Bot fix (no more commands via DM)

### DIFF
--- a/Server/DiscordBot.cs
+++ b/Server/DiscordBot.cs
@@ -1,4 +1,4 @@
-﻿#define SEND_RESP_TO_BAD_REQ_DM // should the bot send a message to people who attempt to run commands/speak in dms
+﻿//#define SEND_RESP_TO_BAD_REQ_DM // should the bot send a message to people who attempt to run commands/speak in dms
 
 using DSharpPlus;
 using DSharpPlus.Entities;

--- a/Server/DiscordBot.cs
+++ b/Server/DiscordBot.cs
@@ -99,7 +99,8 @@ public class DiscordBot {
             DiscordClient.MessageCreated += async (_, args) => {
                 if (args.Author.IsCurrent) return; //dont respond to commands from ourselves (prevent "sql-injection" esq attacks)
 #if LOG_CHANNELS_ON_COMMAND_ATTEMPT_VERBOSE
-                Logger.Info($"Message recieved on channel \"{args.Channel.Id}\", accepting commands from channel \"{Config.LogChannel ?? "(Any Channel)"}\", do channels match: {(args.Channel.Id.ToString() == Config.LogChannel) || (Config.LogChannel == null && !(args.Channel is DiscordDmChannel))}");
+                //Logger.Info($"Message recieved on channel \"{args.Channel.Id}\", accepting commands from channel \"{Config.LogChannel ?? "(Any Channel)"}\", do channels match: {(args.Channel.Id.ToString() == Config.LogChannel) || (Config.LogChannel == null && !(args.Channel is DiscordDmChannel))}");
+                Logger.Info($"cmdchannel == channel id exec ({args.Channel.Id.ToString() == Config.LogChannel})");
 #endif
                 //prevent commands via dm and non-public channels
                 if (Config.LogChannel == null) {

--- a/Server/DiscordBot.cs
+++ b/Server/DiscordBot.cs
@@ -96,6 +96,7 @@ public class DiscordBot {
             Reconnecting = false;
             string mentionPrefix = $"{DiscordClient.CurrentUser.Mention} ";
             DiscordClient.MessageCreated += async (_, args) => {
+                Logger.Info($"Message recieved on channel \"{args.Channel.Id}\", accepting commands from channel \"{Config.LogChannel ?? "(Any Channel)"}\", do channels match: {args.Channel.Id.ToString() == Config.LogChannel}");
                 if (args.Author.IsCurrent) return; //dont respond to commands from ourselves (prevent "sql-injection" esq attacks)
                 //prevent commands via dm and non-public channels
                 if (Config.LogChannel == null) {
@@ -105,7 +106,7 @@ public class DiscordBot {
                     }
                     if (args.Channel is DiscordDmChannel) {
 #if LOG_BAD_REQ
-                        Logger.Warn("A command was sent to the bot in a non-public channel. This will not be processed. (Send commands in the specified LogChannel in settings.json or only in public channels)");
+                        Logger.Warn("A command was sent to the bot in a direct message channel. This will not be processed. (Send commands in the specified LogChannel in settings.json or only in public channels)");
 #endif
 #if SEND_RESP_TO_BAD_REQ
                         await args.Message.RespondAsync("This channel is not valid for running commands. (Your command was not processed).");

--- a/Server/DiscordBot.cs
+++ b/Server/DiscordBot.cs
@@ -1,5 +1,5 @@
-﻿#define SEND_RESP_TO_BAD_REQ
-#define LOG_BAD_REQ
+﻿#define SEND_RESP_TO_BAD_REQ //should the bot send a message to people who attempt to run a command from an invalid location? (Comment out to disable)
+#define LOG_BAD_REQ //should the bot log aformentioned invalid requests?
 
 using DSharpPlus;
 using DSharpPlus.Entities;
@@ -103,7 +103,7 @@ public class DiscordBot {
                         Logger.Warn("You probably should set your LogChannel in settings.json");
                         warnedAboutNullLogChannel = true;
                     }
-                    if (args.Channel.IsPrivate) {
+                    if (args.Channel is DiscordDmChannel) {
 #if LOG_BAD_REQ
                         Logger.Warn("A command was sent to the bot in a non-public channel. This will not be processed. (Send commands in the specified LogChannel in settings.json or only in public channels)");
 #endif

--- a/Server/DiscordBot.cs
+++ b/Server/DiscordBot.cs
@@ -26,6 +26,8 @@ public class DiscordBot {
         });
         if (Config.CommandChannel == null)
             Logger.Warn("You probably should set your CommandChannel in settings.json");
+        if (Config.LogChannel == null)
+            Logger.Warn("You probably should set your LogChannel in settings.json");
         if (Config.Token == null) return;
         Settings.LoadHandler += SettingsLoadHandler;
     }
@@ -103,7 +105,7 @@ public class DiscordBot {
                     if (args.Channel is DiscordDmChannel)
                         return; //no dm'ing the bot allowed!
                 }
-                else if (args.Channel.Id != CommandChannel.Id)
+                else if (args.Channel.Id != CommandChannel.Id && (LogChannel != null && args.Channel.Id != LogChannel.Id))
                     return;
                 //run command
                 try {

--- a/Server/DiscordBot.cs
+++ b/Server/DiscordBot.cs
@@ -91,6 +91,17 @@ public class DiscordBot {
             string mentionPrefix = $"{DiscordClient.CurrentUser.Mention} ";
             DiscordClient.MessageCreated += async (_, args) => {
                 if (args.Author.IsCurrent) return;
+                //prevent commands via dm
+                if (Config.LogChannel == null) {
+                    Logger.Warn("The discord bot cannot process commands because the LogChannel in settings isn't set");
+                    return;
+                }
+                ulong chId = ulong.Parse(Config.LogChannel);
+                if (args.Channel.Id != chId) {
+                    Logger.Warn("A command was sent to the bot in a channel other than the specified log channel (probably attempt to run command via dm)");
+                    return;
+                }
+                //run command
                 try {
                     DiscordMessage msg = args.Message;
                     string? resp = null;

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -73,6 +73,7 @@ public class Settings {
     public class DiscordTable {
         public string? Token { get; set; }
         public string Prefix { get; set; } = "$";
+        public string? CommandChannel { get; set; }
         public string? LogChannel { get; set; }
     }
 


### PR DESCRIPTION
New behavior:

The server bot now no longer runs commands sent via dm (optional error message sent when dm'd, uncomment (hash)define at the top of DiscordBot.cs)
If Config.CommandChannel isn't set, the bot will accept commands from any channel that isn't DM's (not recommended ofc)
If Config.CommandChannel is set, the bot will only accept commands from the command channel

Also, settings.json now has "CommandChannel" and "LogChannel", logs are now sent to the log channel, and commands are to be sent from the command channel (or any non-dm channel if CommandChannel isn't specified).

Also, running commands with the bot via (at)Mentioning the bot now ignores leading whitespace (behavior before was that running commands via this method only worked if there was exactly one space between the end of the mention and the start of the command).