### PR TITLE
fix: on reconnect do not disconnect the new client

### DIFF
--- a/Server/Client.cs
+++ b/Server/Client.cs
@@ -28,6 +28,17 @@ public class Client : IDisposable {
         Logger = new Logger("Unknown User");
     }
 
+    // copy Client to use existing data for a new reconnected connection with a new socket
+    public Client(Client other, Socket socket) {
+        Metadata       = other.Metadata;
+        Connected      = other.Connected;
+        CurrentCostume = other.CurrentCostume;
+        Id             = other.Id;
+        Socket         = socket;
+        Server         = other.Server;
+        Logger         = other.Logger;
+    }
+
     public void Dispose() {
         if (Socket?.Connected is true)
             Socket.Disconnect(false);


### PR DESCRIPTION
Currently when a client connects that is already there, the old socket is closed, and the code tries to reuse the existing client object by exchanging its socket.

Reusing the same client object and just changing its socket does cause issues though with copies of the client in other threads. In the situations that I could reproduce, it always disconnected both sockets, the old one and then the new one.

Instead I make a copy of the client object, use the new socket, remove the old object and add the new object to the collection.

(cherry picked from commit 9e6c312c8e2f4967cf08a6d7c46f6c7779f847f3)