### PR TITLE
fix: don't output empty player IDs or RemoteEndPoints in the log

### DIFF
--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -127,6 +127,7 @@ public class Server {
 
     private async void HandleSocket(Socket socket) {
         Client client = new Client(socket) {Server = this};
+        var remote = socket.RemoteEndPoint;
         IMemoryOwner<byte> memory = null!;
         await client.Send(new InitPacket {
             MaxPlayers = Settings.Instance.Server.MaxPlayers
@@ -142,7 +143,7 @@ public class Server {
                         int size = await socket.ReceiveAsync(readMem[readOffset..readSize], SocketFlags.None);
                         if (size == 0) {
                             // treat it as a disconnect and exit
-                            Logger.Info($"Socket {socket.RemoteEndPoint} disconnected.");
+                            Logger.Info($"Socket {remote} disconnected.");
                             if (socket.Connected) await socket.DisconnectAsync(false);
                             return false;
                         }
@@ -259,7 +260,7 @@ public class Server {
                         tempBuffer.Dispose();
                     });
 
-                    Logger.Info($"Client {client.Name} ({client.Id}/{socket.RemoteEndPoint}) connected.");
+                    Logger.Info($"Client {client.Name} ({client.Id}/{remote}) connected.");
                 } else if (header.Id != client.Id && client.Id != Guid.Empty) {
                     throw new Exception($"Client {client.Name} sent packet with invalid client id {header.Id} instead of {client.Id}");
                 }
@@ -306,7 +307,12 @@ public class Server {
         }
 
         disconnect:
-        Logger.Info($"Client {socket.RemoteEndPoint} ({client.Name}/{client.Id}) disconnected from the server");
+        if (client.Name != "Unknown User" && client.Id != Guid.Parse("00000000-0000-0000-0000-000000000000")) {
+            Logger.Info($"Client {remote} ({client.Name}/{client.Id}) disconnected from the server");
+        }
+        else {
+            Logger.Info($"Client {remote} disconnected from the server");
+        }
 
         // Clients.Remove(client)
         client.Connected = false;


### PR DESCRIPTION
Make and use a copy of the RemoteEndPoint at the start of the HandleSocket method. Because in some cases when the socket is disposed, the RemoteEndPoint inside of it is cleared and isn't available for the following disconnect log entries. Also: port scanners on the internet don't introduce themselves with a name and ID.

(cherry picked from commit 2f4cd0509a683f44eff7b96b1b88efaf65485fb6)