### PR TITLE
only start listening for clients once everything is initialized

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -12,7 +12,6 @@ Server.Server server = new Server.Server();
 HashSet<int> shineBag = new HashSet<int>();
 CancellationTokenSource cts = new CancellationTokenSource();
 bool restartRequested = false;
-Task listenTask = server.Listen(cts.Token);
 Logger consoleLogger = new Logger("Console");
 DiscordBot bot = new DiscordBot();
 await bot.Run();
@@ -654,7 +653,8 @@ Task.Run(() => {
 }).ContinueWith(x => { if (x.Exception != null) { consoleLogger.Error(x.Exception.ToString()); } });
 #pragma warning restore CS4014
 
-await listenTask;
+await server.Listen(cts.Token);
+
 if (restartRequested) //need to do this here because this needs to happen after the listener closes, and there isn't an
                       //easy way to sync in the restartserver command without it exiting Main()
 {


### PR DESCRIPTION
Otherwise clients might connect to the server before everything is ready for them. E.g. when restarting the server, the clients will immediately try to reconnect.

Clients might connect before the `PacketHandler` is initialized, which results in some packets not being processed by the server correctly.

Same goes for the commands: Discord might send in commands before all commands were added to the `CommandHandler`.

Without the `ClientJoined` action, clients might even be allowed to connect if they are on the banlist. (Though without this initialization they or regular clients might be broken in some ways?)

(cherry picked from commit 92e540aaa60ab8fcf4c431e188fe3389ab27e6c1)