### PR TITLE
only broadcast the DisconnectPacket if the client was connected

### DIFF
--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -308,6 +308,8 @@ public class Server {
         disconnect:
         Logger.Info($"Client {socket.RemoteEndPoint} ({client.Name}/{client.Id}) disconnected from the server");
 
+        close:
+        bool wasConnected = client.Connected;
         // Clients.Remove(client)
         client.Connected = false;
         try {
@@ -316,8 +318,10 @@ public class Server {
         catch { /*lol*/ }
 
 #pragma warning disable CS4014
-        Task.Run(() => Broadcast(new DisconnectPacket(), client))
-            .ContinueWith(x => { if (x.Exception != null) { Logger.Error(x.Exception.ToString()); } });
+        if (wasConnected) {
+            Task.Run(() => Broadcast(new DisconnectPacket(), client))
+                .ContinueWith(x => { if (x.Exception != null) { Logger.Error(x.Exception.ToString()); } });
+        }
 #pragma warning restore CS4014
     }
 

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -308,7 +308,6 @@ public class Server {
         disconnect:
         Logger.Info($"Client {socket.RemoteEndPoint} ({client.Name}/{client.Id}) disconnected from the server");
 
-        close:
         bool wasConnected = client.Connected;
         // Clients.Remove(client)
         client.Connected = false;


### PR DESCRIPTION
Otherwise port scans, banned players or clients failing to initialize correctly, will cause the server to send unnecessary packets to all connected clients.

They currently are informed about a disconnect for a client that hasn't even connected correctly.

(cherry picked from commit 4b04a3d5bec1a86cacda20da13dd41ebbdb05a88)