### PR TITLE
only warn about the Discord channel settings when a Token is set

### DIFF
--- a/Server/DiscordBot.cs
+++ b/Server/DiscordBot.cs
@@ -24,11 +24,11 @@ public class DiscordBot {
             Task.Run(Reconnect);
             return "Restarting Discord bot";
         });
+        if (Config.Token == null) return;
         if (Config.CommandChannel == null)
             Logger.Warn("You probably should set your CommandChannel in settings.json");
         if (Config.LogChannel == null)
             Logger.Warn("You probably should set your LogChannel in settings.json");
-        if (Config.Token == null) return;
         Settings.LoadHandler += SettingsLoadHandler;
     }
 


### PR DESCRIPTION
Servers that don't use Discord (default settings) don't need to be warned about not setting Discord channels.