### PR TITLE
build binary files via docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/Server/bin/
+/Server/obj/
+/Shared/bin/
+/Shared/obj/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,3 +73,35 @@ jobs:
         platforms  : linux/amd64,linux/arm/v7,linux/arm64/v8
         cache-from : type=gha,scope=${{ github.workflow }}
         cache-to   : type=gha,scope=${{ github.workflow }},mode=max
+    -
+      name: Build binary files
+      run: |
+        ./docker-build.sh  all
+    -
+      name : Upload Server
+      uses : actions/upload-artifact@v3
+      with:
+        name              : Server
+        path              : ./bin/Server
+        if-no-files-found : error
+    -
+      name : Upload Server.arm
+      uses : actions/upload-artifact@v3
+      with:
+        name              : Server.arm
+        path              : ./bin/Server.arm
+        if-no-files-found : error
+    -
+      name : Upload Server.arm64
+      uses : actions/upload-artifact@v3
+      with:
+        name              : Server.arm64
+        path              : ./bin/Server.arm64
+        if-no-files-found : error
+    -
+      name : Upload Server.exe
+      uses : actions/upload-artifact@v3
+      with:
+        name              : Server.exe
+        path              : ./bin/Server.exe
+        if-no-files-found : error

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ riderModule.iml
 .idea/
 settings.json
 .vs/
+
+/cache/
+/data/

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$#" == "0" ]] || [[ "$#" > "1" ]] || ! [[ "$1" =~ ^(all|x64|arm|arm64|win64)$ ]] ; then
+  echo "Usage: docker-build.sh {all|x64|arm|arm64|win64}"
+  exit 1
+fi
+
+DIR=$(dirname "$(realpath $0)")
+cd "$DIR"
+
+declare -A archs=(
+  ["x64"]="linux-x64"
+  ["arm"]="linux-arm"
+  ["arm64"]="linux-arm64"
+  ["win64"]="win-x64"
+)
+
+for sub in "${!archs[@]}" ; do
+  arch="${archs[$sub]}"
+
+  if [[ "$1" != "all" ]] && [[ "$1" != "$sub" ]] ; then
+    continue
+  fi
+
+  docker  run                         \
+    -u `id -u`:`id -g`                \
+    -v "/$DIR/"://app/                \
+    -w //app/                         \
+    -e DOTNET_CLI_HOME=//app/cache/   \
+    -e XDG_DATA_HOME=//app/cache/     \
+    mcr.microsoft.com/dotnet/sdk:6.0  \
+      dotnet  publish                 \
+        ./Server/Server.csproj        \
+        -r $arch                      \
+        -c Release                    \
+        -o /app/bin/$sub/             \
+        --self-contained              \
+        -p:publishSingleFile=true     \
+  ;
+
+  filename="Server"
+  ext=""
+  if   [[ "$sub" == "arm"   ]] ; then filename="Server.arm";
+  elif [[ "$sub" == "arm64" ]] ; then filename="Server.arm64";
+  elif [[ "$sub" == "win64" ]] ; then filename="Server.exe"; ext=".exe";
+  fi
+
+  mv  ./bin/$sub/Server$ext  ./bin/$filename
+  rm  -rf  ./bin/$sub/
+done


### PR DESCRIPTION
Build binary executables for all platforms during the `build and deploy` workflow and attach them to the artifacts.

Example: https://github.com/Istador/SmoOnlineServer/actions/runs/3736033391

What we could also do if wanted (in a separate PR):
when pushing a version tag, e.g. `1.0.4`, then automatically build it, create a release for it and attach the binary files to it.