### PR TITLE
fix: synchronization issues

### DIFF
--- a/Server/Client.cs
+++ b/Server/Client.cs
@@ -76,6 +76,17 @@ public class Client : IDisposable {
         await Socket!.SendAsync(data[..(Constants.HeaderSize + header.PacketSize)], SocketFlags.None);
     }
 
+    public void CleanMetadataOnNewConnection() {
+        object? tmp;
+        Metadata.TryRemove("time",              out tmp);
+        Metadata.TryRemove("seeking",           out tmp);
+        Metadata.TryRemove("lastCostumePacket", out tmp);
+        Metadata.TryRemove("lastCapturePacket", out tmp);
+        Metadata.TryRemove("lastTagPacket",     out tmp);
+        Metadata.TryRemove("lastGamePacket",    out tmp);
+        Metadata.TryRemove("lastPlayerPacket",  out tmp);
+    }
+
     public static bool operator ==(Client? left, Client? right) {
         return left is { } leftClient && right is { } rightClient && leftClient.Id == rightClient.Id;
     }

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -64,7 +64,7 @@ public class Server {
 
     public static void FillPacket<T>(PacketHeader header, T packet, Memory<byte> memory) where T : struct, IPacket {
         Span<byte> data = memory.Span;
-        
+
         header.Serialize(data[..Constants.HeaderSize]);
         packet.Serialize(data[Constants.HeaderSize..]);
     }
@@ -174,6 +174,8 @@ public class Server {
 
                     ConnectPacket connect = new ConnectPacket();
                     connect.Deserialize(memory.Memory.Span[packetRange]);
+                    bool wasFirst = connect.ConnectionType == ConnectPacket.ConnectionTypes.FirstConnection;
+
                     lock (Clients) {
                         if (Clients.Count(x => x.Connected) == Settings.Instance.Server.MaxPlayers) {
                             client.Logger.Error($"Turned away as server is at max clients");
@@ -218,27 +220,35 @@ public class Server {
                             // done disconnecting and removing stale clients with the same id
 
                             ClientJoined?.Invoke(client, connect);
+                        // a new connection, not a reconnect, for an existing client
+                        } else if (wasFirst) {
+                            client.CleanMetadataOnNewConnection();
                         }
                     }
 
+                    // for all other clients that are already connected
                     List<Client> otherConnectedPlayers = Clients.FindAll(c => c.Id != header.Id && c.Connected && c.Socket != null);
                     await Parallel.ForEachAsync(otherConnectedPlayers, async (other, _) => {
                         IMemoryOwner<byte> tempBuffer = MemoryPool<byte>.Shared.RentZero(Constants.HeaderSize + (other.CurrentCostume.HasValue ? Math.Max(connect.Size, other.CurrentCostume.Value.Size) : connect.Size));
+
+                        // make the other client known to the (new) client
                         PacketHeader connectHeader = new PacketHeader {
-                            Id = other.Id,
-                            Type = PacketType.Connect,
-                            PacketSize = connect.Size
+                            Id         = other.Id,
+                            Type       = PacketType.Connect,
+                            PacketSize = connect.Size,
                         };
                         connectHeader.Serialize(tempBuffer.Memory.Span[..Constants.HeaderSize]);
                         ConnectPacket connectPacket = new ConnectPacket {
                             ConnectionType = ConnectPacket.ConnectionTypes.FirstConnection, // doesn't matter what it is
-                            MaxPlayers = Settings.Instance.Server.MaxPlayers,
-                            ClientName = other.Name
+                            MaxPlayers     = Settings.Instance.Server.MaxPlayers,
+                            ClientName     = other.Name,
                         };
                         connectPacket.Serialize(tempBuffer.Memory.Span[Constants.HeaderSize..]);
                         await client.Send(tempBuffer.Memory[..(Constants.HeaderSize + connect.Size)], null);
+
+                        // tell the (new) client what costume the other client has
                         if (other.CurrentCostume.HasValue) {
-                            connectHeader.Type = PacketType.Costume;
+                            connectHeader.Type       = PacketType.Costume;
                             connectHeader.PacketSize = other.CurrentCostume.Value.Size;
                             connectHeader.Serialize(tempBuffer.Memory.Span[..Constants.HeaderSize]);
                             other.CurrentCostume.Value.Serialize(tempBuffer.Memory.Span[Constants.HeaderSize..(Constants.HeaderSize + connectHeader.PacketSize)]);
@@ -246,9 +256,17 @@ public class Server {
                         }
 
                         tempBuffer.Dispose();
+
+                        // make the other client reset their puppet cache for this client, if it is a new connection (after restart)
+                        if (wasFirst) {
+                            await SendEmptyPackets(client, other);
+                        }
                     });
 
                     Logger.Info($"Client {client.Name} ({client.Id}/{remote}) connected.");
+
+                    // send missing or outdated packets from others to the new client
+                    await ResendPackets(client);
                 } else if (header.Id != client.Id && client.Id != Guid.Empty) {
                     throw new Exception($"Client {client.Name} sent packet with invalid client id {header.Id} instead of {client.Id}");
                 }
@@ -308,6 +326,38 @@ public class Server {
                 .ContinueWith(x => { if (x.Exception != null) { Logger.Error(x.Exception.ToString()); } });
         }
 #pragma warning restore CS4014
+    }
+
+    private async Task ResendPackets(Client client) {
+        async Task trySend<T>(Client other, string packetType) where T : struct, IPacket {
+            if (! other.Metadata.ContainsKey(packetType)) { return; }
+            try {
+                await client.Send((T) other.Metadata[packetType]!, other);
+            }
+            catch {
+                // lol who gives a fuck
+            }
+        };
+        await Parallel.ForEachAsync(this.ClientsConnected, async (other, _) => {
+            if (client.Id == other.Id) { return; }
+            await trySend<CostumePacket>(other, "lastCostumePacket");
+            await trySend<CapturePacket>(other, "lastCapturePacket");
+            await trySend<TagPacket>(other, "lastTagPacket");
+            await trySend<GamePacket>(other, "lastGamePacket");
+            await trySend<PlayerPacket>(other, "lastPlayerPacket");
+        });
+    }
+
+    private async Task SendEmptyPackets(Client client, Client other) {
+        await other.Send(new TagPacket {
+            UpdateType = TagPacket.TagUpdate.State | TagPacket.TagUpdate.Time,
+            IsIt       = false,
+            Seconds    = 0,
+            Minutes    = 0,
+        }, client);
+        await other.Send(new CapturePacket {
+            ModelName = "",
+        }, client);
     }
 
     private static PacketHeader GetHeader(Span<byte> data) {


### PR DESCRIPTION
- Send empty `TagPacket` and `CapturePacket` on new connections, to reset old data back that other players might still have in their puppet from an earlier connection.
- Cache and send `CostumePacket`, `CapturePacket`, `TagPacket`, `GamePacket` and `PlayerPacket` to (re-)connecting players.
- Clear Metadata cache for existing clients that connect fresh (after a game restart).

This fixes the faulty behaviours `1`, `3`, `4` and `6` described in https://github.com/CraftyBoss/SuperMarioOdysseyOnline/pull/54 on the server side (for old unpatched clients). The behaviours `2` and `5` can only be fixed in the client.