### PR TITLE
fix: construct tag packet instead of caching it in memory

### DIFF
--- a/Server/Client.cs
+++ b/Server/Client.cs
@@ -83,9 +83,20 @@ public class Client : IDisposable {
         Metadata.TryRemove("seeking",           out tmp);
         Metadata.TryRemove("lastCostumePacket", out tmp);
         Metadata.TryRemove("lastCapturePacket", out tmp);
-        Metadata.TryRemove("lastTagPacket",     out tmp);
         Metadata.TryRemove("lastGamePacket",    out tmp);
         Metadata.TryRemove("lastPlayerPacket",  out tmp);
+    }
+
+    public TagPacket? GetTagPacket() {
+        var time = (Time?) this.Metadata?["time"];
+        var seek = (bool?) this.Metadata?["seeking"];
+        if (time == null && seek == null) { return null; }
+        return new TagPacket {
+            UpdateType = (seek != null ? TagPacket.TagUpdate.State : 0) | (time != null ? TagPacket.TagUpdate.Time: 0),
+            IsIt       = seek ?? false,
+            Seconds    = (byte)   (time?.Seconds ?? 0),
+            Minutes    = (ushort) (time?.Minutes ?? 0),
+        };
     }
 
     public static bool operator ==(Client? left, Client? right) {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -172,7 +172,6 @@ server.PacketHandler = (c, p) => {
 
         case TagPacket tagPacket: {
             // c.Logger.Info($"Got tag packet: {tagPacket.IsIt}");
-            c.Metadata["lastTagPacket"] = tagPacket;
             if ((tagPacket.UpdateType & TagPacket.TagUpdate.State) != 0) c.Metadata["seeking"] = tagPacket.IsIt;
             if ((tagPacket.UpdateType & TagPacket.TagUpdate.Time) != 0)
                 c.Metadata["time"] = new Time(tagPacket.Minutes, tagPacket.Seconds, DateTime.Now);


### PR DESCRIPTION
Because the tag packet received from the client could have an `UpdateType` that isn't both `State` and `Time`. (Though currently the client always updates both together.)