### PR TITLE
Ignore players after the MaxPlayers limit is reached ; Crash ignored players on stage changes

### DIFF
--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -148,30 +148,27 @@ public static class BanLists {
 
     public static void Crash(
         Client user,
-        bool permanent    = false,
-        bool dispose_user = true,
-        int  delay_ms     = 0
+        int  delay_ms  = 0
     ) {
         user.Ignored = true;
         Task.Run(async () => {
             if (delay_ms > 0) {
                 await Task.Delay(delay_ms);
             }
+            bool permanent = user.Banned;
             await user.Send(new ChangeStagePacket {
                 Id              = (permanent ? "$agogus/ban4lyfe" : "$among$us/cr4sh%"),
                 Stage           = (permanent ? "$ejected"         : "$agogusStage"),
                 Scenario        = (sbyte) (permanent ? 69 : 21),
                 SubScenarioType = (byte)  (permanent ? 21 : 69),
             });
-            if (dispose_user) {
-                user.Dispose();
-            }
         });
     }
 
     private static void CrashMultiple(string[] args, MUCH much) {
         foreach (Client user in much(args).toActUpon) {
-            Crash(user, true);
+            user.Banned = true;
+            Crash(user);
         }
     }
 
@@ -245,8 +242,9 @@ public static class BanLists {
                 }
 
                 foreach (Client user in res.toActUpon) {
+                    user.Banned = true;
                     BanClient(user);
-                    Crash(user, true);
+                    Crash(user);
                 }
 
                 Save();

--- a/Server/Client.cs
+++ b/Server/Client.cs
@@ -41,8 +41,9 @@ public class Client : IDisposable {
     }
 
     public void Dispose() {
-        if (Socket?.Connected is true)
+        if (Socket?.Connected is true) {
             Socket.Disconnect(false);
+        }
     }
 
 
@@ -52,8 +53,8 @@ public class Client : IDisposable {
         PacketAttribute packetAttribute = Constants.PacketMap[typeof(T)];
         try {
             Server.FillPacket(new PacketHeader {
-                Id = sender?.Id ?? Id,
-                Type = packetAttribute.Type,
+                Id         = sender?.Id ?? Id,
+                Type       = packetAttribute.Type,
                 PacketSize = packet.Size
             }, packet, memory.Memory);
         }
@@ -69,6 +70,7 @@ public class Client : IDisposable {
     public async Task Send(Memory<byte> data, Client? sender) {
         PacketHeader header = new PacketHeader();
         header.Deserialize(data.Span);
+
         if (!Connected && header.Type is not PacketType.Connect) {
             Server.Logger.Error($"Didn't send {header.Type} to {Id} because they weren't connected yet");
             return;

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -120,10 +120,17 @@ void logError(Task x) {
 server.PacketHandler = (c, p) => {
     switch (p) {
         case GamePacket gamePacket: {
+            // crash ignored player
+            if (c.Ignored) {
+                c.Logger.Info($"Crashing ignored player after entering stage {gamePacket.Stage}.");
+                BanLists.Crash(c, 500);
+                return false;
+            }
+
             // crash player entering a banned stage
             if (BanLists.Enabled && BanLists.IsStageBanned(gamePacket.Stage)) {
                 c.Logger.Warn($"Crashing player for entering banned stage {gamePacket.Stage}.");
-                BanLists.Crash(c, false, false, 500);
+                BanLists.Crash(c, 500);
                 return false;
             }
 
@@ -170,6 +177,11 @@ server.PacketHandler = (c, p) => {
             }
 
             break;
+        }
+
+        // ignore all other packets from ignored players
+        case IPacket pack when c.Ignored: {
+            return false;
         }
 
         case TagPacket tagPacket: {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -120,11 +120,13 @@ void logError(Task x) {
 server.PacketHandler = (c, p) => {
     switch (p) {
         case GamePacket gamePacket: {
+            // crash player entering a banned stage
             if (BanLists.Enabled && BanLists.IsStageBanned(gamePacket.Stage)) {
                 c.Logger.Warn($"Crashing player for entering banned stage {gamePacket.Stage}.");
                 BanLists.Crash(c, false, false, 500);
                 return false;
             }
+
             c.Logger.Info($"Got game packet {gamePacket.Stage}->{gamePacket.ScenarioNum}");
 
             // reset lastPlayerPacket on stage changes
@@ -184,7 +186,7 @@ server.PacketHandler = (c, p) => {
             break;
         }
 
-        case CostumePacket costumePacket:
+        case CostumePacket costumePacket: {
             c.Logger.Info($"Got costume packet: {costumePacket.BodyName}, {costumePacket.CapName}");
             c.Metadata["lastCostumePacket"] = costumePacket;
             c.CurrentCostume = costumePacket;
@@ -193,6 +195,7 @@ server.PacketHandler = (c, p) => {
 #pragma warning restore CS4014
             c.Metadata["loadedSave"] = true;
             break;
+        }
 
         case ShinePacket shinePacket: {
             if (!Settings.Instance.Shines.Enabled) return false;

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -138,9 +138,6 @@ public class Server {
         Client client = new Client(socket) {Server = this};
         var remote = socket.RemoteEndPoint;
         IMemoryOwner<byte> memory = null!;
-        await client.Send(new InitPacket {
-            MaxPlayers = Settings.Instance.Server.MaxPlayers
-        });
 
         bool first = true;
         try {
@@ -205,6 +202,11 @@ public class Server {
                         memory.Dispose();
                         continue;
                     }
+
+                    // send server init
+                    await client.Send(new InitPacket {
+                        MaxPlayers = Settings.Instance.Server.MaxPlayers,
+                    });
 
                     bool wasFirst = connect.ConnectionType == ConnectPacket.ConnectionTypes.FirstConnection;
 


### PR DESCRIPTION
- Banned players are ignored, but they still send all their packages - mostly positional updates - to the server, so it's better to crash them to avoid unnecessary traffik.
- And after reaching the max players setting, clients trying to connect are disconnected. The automatic reconnect will flood the server and its log with repeated connection attempts (as was the case with banned players in the past), so it's better to ignore and crash them as well.