### PR TITLE
fix: only parse time & seeking from TagPackets for Hide&Seek or Sardines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,11 @@ jobs:
         echo "IMAGE=$IMAGE"  >>$GITHUB_ENV
     -
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     -
       id: meta
       name: Docker meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: |
           ghcr.io/${{ env.IMAGE }}
@@ -47,22 +47,22 @@ jobs:
           org.opencontainers.image.licenses=UNLICENSED
     -
       name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: amd64,arm64,arm
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     -
       name: Login to GHCR
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry : ghcr.io
         username : ${{ github.repository_owner }}
         password : ${{ secrets.GITHUB_TOKEN }}
     -
       name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         pull       : true
         push       : true
@@ -79,28 +79,28 @@ jobs:
         ./docker-build.sh  all
     -
       name : Upload Server
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server
         path              : ./bin/Server
         if-no-files-found : error
     -
       name : Upload Server.arm
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server.arm
         path              : ./bin/Server.arm
         if-no-files-found : error
     -
       name : Upload Server.arm64
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server.arm64
         path              : ./bin/Server.arm64
         if-no-files-found : error
     -
       name : Upload Server.exe
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server.exe
         path              : ./bin/Server.exe

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,18 +15,18 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     -
       name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: amd64,arm64,arm
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     -
       name: Build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         pull       : true
         push       : false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ################################################################################
 ##################################################################   build   ###
 
-FROM  --platform=linux/amd64  mcr.microsoft.com/dotnet/sdk:6.0  as  build
+FROM  --platform=${BUILDPLATFORM}  mcr.microsoft.com/dotnet/sdk:6.0  AS  build
 
 WORKDIR  /app/
 
@@ -34,7 +34,7 @@ RUN  dotnet  publish  \
 ################################################################################
 ################################################################   runtime   ###
 
-FROM  mcr.microsoft.com/dotnet/runtime:6.0  as  runtime
+FROM  mcr.microsoft.com/dotnet/runtime:6.0  AS  runtime
 
 # Copy application binary from build stage
 COPY  --from=build  /app/out/  /app/

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -37,6 +37,12 @@ public static class BanLists {
         }
     }
 
+    private static ISet<sbyte> GameModes {
+        get {
+            return Settings.Instance.BanList.GameModes;
+        }
+    }
+
 
     private static bool IsIPv4(string str) {
         return IPAddress.TryParse(str, out IPAddress? ip)
@@ -71,6 +77,10 @@ public static class BanLists {
 
     public static bool IsStageBanned(string stage) {
         return Stages.Contains(stage);
+    }
+
+    public static bool IsGameModeBanned(GameMode gameMode) {
+        return GameModes.Contains((sbyte)gameMode);
     }
 
     public static bool IsClientBanned(Client user) {

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -154,6 +154,10 @@ public static class BanLists {
         Stages.Remove(stage);
     }
 
+    private static void UnbanGameMode(GameMode gameMode) {
+        GameModes.Remove((sbyte)gameMode);
+    }
+
 
     private static void Save() {
         Settings.SaveSettings(true);
@@ -387,6 +391,17 @@ public static class BanLists {
                 }
                 Save();
                 return "Unbanned stage: " + string.Join(", ", stages);
+
+            case "gamemode":
+                if (!GameMode.TryParse(val, out GameMode gameMode)) {
+                    return "Invalid gamemode value!";
+                }
+                if (!IsGameModeBanned(gameMode)) {
+                    return "Gamemode " + gameMode + " is not banned.";
+                }
+                UnbanGameMode(gameMode);
+                Save();
+                return "Unbanned gamemode: " + gameMode;
         }
     }
 }

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -217,6 +217,11 @@ public static class BanLists {
                     list.Append(string.Join("\n- ", Stages));
                 }
 
+                if (GameModes.Count > 0) {
+                    list.Append("\nBanned gamemodes:\n- ");
+                    list.Append(string.Join("\n- ", GameModes.Select(x => (GameMode)x)));
+                }
+
                 return list.ToString();
 
             case "enable":

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -116,6 +116,10 @@ public static class BanLists {
         Stages.Add(stage);
     }
 
+    private static void BanGameMode(GameMode gameMode) {
+        GameModes.Add((sbyte)gameMode);
+    }
+
     private static void BanClient(Client user) {
         BanProfile(user);
         BanIPv4(user);
@@ -316,6 +320,20 @@ public static class BanLists {
                 }
                 Save();
                 return "Banned stage: " + string.Join(", ", stages);
+
+            case "gamemode":
+                if (args.Length != 1) {
+                    return "Usage: ban gamemode <gamemode>";
+                }
+                if (!GameMode.TryParse(args[0], out GameMode gameMode)) {
+                    return "Invalid gamemode value!";
+                }
+                if (IsGameModeBanned(gameMode)) {
+                    return "Gamemode " + gameMode + " is already banned.";
+                }
+                BanGameMode(gameMode);
+                Save();
+                return "Banned gamemode: " + gameMode;
         }
     }
 

--- a/Server/Client.cs
+++ b/Server/Client.cs
@@ -92,6 +92,7 @@ public class Client : IDisposable {
 
     public void CleanMetadataOnNewConnection() {
         object? tmp;
+        Metadata.TryRemove("gameMode",          out tmp);
         Metadata.TryRemove("time",              out tmp);
         Metadata.TryRemove("seeking",           out tmp);
         Metadata.TryRemove("lastCostumePacket", out tmp);
@@ -101,10 +102,19 @@ public class Client : IDisposable {
     }
 
     public TagPacket? GetTagPacket() {
+        var gmode = (GameMode?) (this.Metadata.ContainsKey("gameMode") ? this.Metadata["gameMode"] : null);
+        if (gmode == null) { return null; }
+        if (   gmode != GameMode.Legacy
+            && gmode != GameMode.HideAndSeek
+            && gmode != GameMode.Sardines
+        ) { return null; }
+
         var time = (Time?) (this.Metadata.ContainsKey("time")    ? this.Metadata["time"]    : null);
         var seek = (bool?) (this.Metadata.ContainsKey("seeking") ? this.Metadata["seeking"] : null);
         if (time == null && seek == null) { return null; }
+
         return new TagPacket {
+            GameMode   = (GameMode) gmode,
             UpdateType = (seek != null ? TagPacket.TagUpdate.State : 0) | (time != null ? TagPacket.TagUpdate.Time: 0),
             IsIt       = seek ?? false,
             Seconds    = (byte)   (time?.Seconds ?? 0),

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -192,6 +192,12 @@ server.PacketHandler = (c, p) => {
         }
 
         case TagPacket tagPacket: {
+            if (BanLists.Enabled && BanLists.IsGameModeBanned(tagPacket.GameMode)) {
+                c.Logger.Warn($"Crashing player for entering banned gamemode {tagPacket.GameMode}.");
+                BanLists.Crash(c, 500);
+                return false;
+            }
+
             if (  (tagPacket.GameMode == GameMode.Legacy && tagPacket.UpdateType == TagPacket.TagUpdate.Both)
                 || tagPacket.GameMode == GameMode.HideAndSeek
                 || tagPacket.GameMode == GameMode.Sardines
@@ -209,6 +215,7 @@ server.PacketHandler = (c, p) => {
                 c.Metadata["time"]    = null;
             }
             c.Metadata["gameMode"] = tagPacket.GameMode;
+
             break;
         }
 

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -408,7 +408,8 @@ public class Server {
 
     private async Task SendEmptyPackets(Client client, Client other) {
         await other.Send(new TagPacket {
-            UpdateType = TagPacket.TagUpdate.State | TagPacket.TagUpdate.Time,
+            GameMode   = GameMode.Legacy,
+            UpdateType = TagPacket.TagUpdate.Both,
             IsIt       = false,
             Seconds    = 0,
             Minutes    = 0,

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -63,6 +63,7 @@ public class Settings {
         public ISet<Guid> Players { get; set; } = new SortedSet<Guid>();
         public ISet<string> IpAddresses { get; set; } = new SortedSet<string>();
         public ISet<string> Stages { get; set; } = new SortedSet<string>();
+        public ISet<sbyte> GameModes { get; set; } = new SortedSet<sbyte>();
     }
 
     public class FlipTable {

--- a/Shared/Packet/Packets/TagPacket.cs
+++ b/Shared/Packet/Packets/TagPacket.cs
@@ -4,6 +4,7 @@ namespace Shared.Packet.Packets;
 
 [Packet(PacketType.Tag)]
 public struct TagPacket : IPacket {
+    public GameMode GameMode;
     public TagUpdate UpdateType;
     public bool IsIt;
     public byte Seconds;
@@ -12,22 +13,58 @@ public struct TagPacket : IPacket {
     public short Size => 5;
 
     public void Serialize(Span<byte> data) {
-        MemoryMarshal.Write(data, ref UpdateType);
+        byte both = (byte)((byte) UpdateType | ((byte) GameMode << 4));
+        MemoryMarshal.Write(data,      ref both);
         MemoryMarshal.Write(data[1..], ref IsIt);
         MemoryMarshal.Write(data[2..], ref Seconds);
         MemoryMarshal.Write(data[3..], ref Minutes);
     }
 
     public void Deserialize(ReadOnlySpan<byte> data) {
-        UpdateType = MemoryMarshal.Read<TagUpdate>(data);
-        IsIt = MemoryMarshal.Read<bool>(data[1..]);
-        Seconds = MemoryMarshal.Read<byte>(data[2..]);
-        Minutes = MemoryMarshal.Read<ushort>(data[3..]);
+        byte both  = MemoryMarshal.Read<byte>(data);
+        GameMode   = (GameMode) (sbyte) (((((both & (byte) 0xf0) >> 4) + 1) % 16) - 1);
+        UpdateType = (TagUpdate) (byte) (both & (byte) 0x0f);
+        IsIt       = MemoryMarshal.Read<bool>(data[1..]);
+        Seconds    = MemoryMarshal.Read<byte>(data[2..]);
+        Minutes    = MemoryMarshal.Read<ushort>(data[3..]);
     }
 
     [Flags]
     public enum TagUpdate : byte {
-        Time = 1,
-        State = 2
+        None      =  0,
+        Time      =  1,
+        State     =  2,
+        Both      =  3,
+        Unknown04 =  4,
+        Unknown05 =  5,
+        Unknown06 =  6,
+        Unknown07 =  7,
+        Unknown08 =  8,
+        Unknown09 =  9,
+        Unknown10 = 10,
+        Unknown11 = 11,
+        Unknown12 = 12,
+        Unknown13 = 13,
+        Unknown14 = 14,
+        All       = 15,
     }
+}
+
+public enum GameMode : sbyte {
+    None        = -1,
+    Legacy      =  0,
+    HideAndSeek =  1,
+    Sardines    =  2,
+    FreezeTag   =  3,
+    Unknown04   =  4,
+    Unknown05   =  5,
+    Unknown06   =  6,
+    Unknown07   =  7,
+    Unknown08   =  8,
+    Unknown09   =  9,
+    Unknown10   = 10,
+    Unknown11   = 11,
+    Unknown12   = 12,
+    Unknown13   = 13,
+    Reserved    = 14, // extension possibility for more future game modes with an extra added byte
 }


### PR DESCRIPTION
Freeze-Tag uses the same `UpdateType` flags for some of its `TagPacket`s as H&S and Sardines do.
But Freeze-Tag has another packet data structure that isn't matching `IsIt`, `Seconds` and `Minutes`.
Therefore the server wrongly interprets Freeze-Tag packets and updates its `"seeking"` and `"time"` metadata wrongly.
(These metadata fields are used to resend the `TagPacket` to later joining clients.)

This PR does the following changes:
- 479e37a7f4ecc22ec23b10f920c87d5d52386254
  - update: external actions in `.github/workflows/` to the newest versions
- 189ac2dcd65ac1001d85b4b27e9fb31061937f6b
  - fix: `Dockerfile` to avoid 3 warning messages
- 765af57eb4afa342e97c907462be4c8237bad9a1
  - add: game mode detection in the first 4 bit of the `TagPacket.UpdateType`
  - change: parse the `TagPacket` for the metadata iff it is clearly for H&S or Sardines
  - change: only resend `TagPacket` to new clients for H&S or Sardines