### PR TITLE
JSON API & fix: only parse time & seeking from TagPackets for Hide&Seek or Sardines

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,8 @@
 /Server/obj/
 /Shared/bin/
 /Shared/obj/
+
+/Server/**/.gitignore
+/Server/**/*.env
+/Server/**/*.md
+/Server/**/*.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,11 @@ jobs:
         echo "IMAGE=$IMAGE"  >>$GITHUB_ENV
     -
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     -
       id: meta
       name: Docker meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: |
           ghcr.io/${{ env.IMAGE }}
@@ -47,22 +47,22 @@ jobs:
           org.opencontainers.image.licenses=UNLICENSED
     -
       name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: amd64,arm64,arm
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     -
       name: Login to GHCR
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry : ghcr.io
         username : ${{ github.repository_owner }}
         password : ${{ secrets.GITHUB_TOKEN }}
     -
       name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         pull       : true
         push       : true
@@ -79,28 +79,28 @@ jobs:
         ./docker-build.sh  all
     -
       name : Upload Server
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server
         path              : ./bin/Server
         if-no-files-found : error
     -
       name : Upload Server.arm
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server.arm
         path              : ./bin/Server.arm
         if-no-files-found : error
     -
       name : Upload Server.arm64
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server.arm64
         path              : ./bin/Server.arm64
         if-no-files-found : error
     -
       name : Upload Server.exe
-      uses : actions/upload-artifact@v3
+      uses : actions/upload-artifact@v4
       with:
         name              : Server.exe
         path              : ./bin/Server.exe

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,18 +15,18 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     -
       name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: amd64,arm64,arm
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     -
       name: Build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         pull       : true
         push       : false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ################################################################################
 ##################################################################   build   ###
 
-FROM  --platform=linux/amd64  mcr.microsoft.com/dotnet/sdk:6.0  as  build
+FROM  --platform=${BUILDPLATFORM}  mcr.microsoft.com/dotnet/sdk:6.0  AS  build
 
 WORKDIR  /app/
 
@@ -34,7 +34,7 @@ RUN  dotnet  publish  \
 ################################################################################
 ################################################################   runtime   ###
 
-FROM  mcr.microsoft.com/dotnet/runtime:6.0  as  runtime
+FROM  mcr.microsoft.com/dotnet/runtime:6.0  AS  runtime
 
 # Copy application binary from build stage
 COPY  --from=build  /app/out/  /app/

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -37,6 +37,12 @@ public static class BanLists {
         }
     }
 
+    private static ISet<sbyte> GameModes {
+        get {
+            return Settings.Instance.BanList.GameModes;
+        }
+    }
+
 
     private static bool IsIPv4(string str) {
         return IPAddress.TryParse(str, out IPAddress? ip)
@@ -71,6 +77,10 @@ public static class BanLists {
 
     public static bool IsStageBanned(string stage) {
         return Stages.Contains(stage);
+    }
+
+    public static bool IsGameModeBanned(GameMode gameMode) {
+        return GameModes.Contains((sbyte)gameMode);
     }
 
     public static bool IsClientBanned(Client user) {

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -154,6 +154,10 @@ public static class BanLists {
         Stages.Remove(stage);
     }
 
+    private static void UnbanGameMode(GameMode gameMode) {
+        GameModes.Remove((sbyte)gameMode);
+    }
+
 
     private static void Save() {
         Settings.SaveSettings(true);
@@ -387,6 +391,17 @@ public static class BanLists {
                 }
                 Save();
                 return "Unbanned stage: " + string.Join(", ", stages);
+
+            case "gamemode":
+                if (!GameMode.TryParse(val, out GameMode gameMode)) {
+                    return "Invalid gamemode value!";
+                }
+                if (!IsGameModeBanned(gameMode)) {
+                    return "Gamemode " + gameMode + " is not banned.";
+                }
+                UnbanGameMode(gameMode);
+                Save();
+                return "Unbanned gamemode: " + gameMode;
         }
     }
 }

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -217,6 +217,11 @@ public static class BanLists {
                     list.Append(string.Join("\n- ", Stages));
                 }
 
+                if (GameModes.Count > 0) {
+                    list.Append("\nBanned gamemodes:\n- ");
+                    list.Append(string.Join("\n- ", GameModes.Select(x => (GameMode)x)));
+                }
+
                 return list.ToString();
 
             case "enable":

--- a/Server/BanLists.cs
+++ b/Server/BanLists.cs
@@ -116,6 +116,10 @@ public static class BanLists {
         Stages.Add(stage);
     }
 
+    private static void BanGameMode(GameMode gameMode) {
+        GameModes.Add((sbyte)gameMode);
+    }
+
     private static void BanClient(Client user) {
         BanProfile(user);
         BanIPv4(user);
@@ -316,6 +320,20 @@ public static class BanLists {
                 }
                 Save();
                 return "Banned stage: " + string.Join(", ", stages);
+
+            case "gamemode":
+                if (args.Length != 1) {
+                    return "Usage: ban gamemode <gamemode>";
+                }
+                if (!GameMode.TryParse(args[0], out GameMode gameMode)) {
+                    return "Invalid gamemode value!";
+                }
+                if (IsGameModeBanned(gameMode)) {
+                    return "Gamemode " + gameMode + " is already banned.";
+                }
+                BanGameMode(gameMode);
+                Save();
+                return "Banned gamemode: " + gameMode;
         }
     }
 

--- a/Server/Client.cs
+++ b/Server/Client.cs
@@ -92,6 +92,7 @@ public class Client : IDisposable {
 
     public void CleanMetadataOnNewConnection() {
         object? tmp;
+        Metadata.TryRemove("gameMode",          out tmp);
         Metadata.TryRemove("time",              out tmp);
         Metadata.TryRemove("seeking",           out tmp);
         Metadata.TryRemove("lastCostumePacket", out tmp);
@@ -101,10 +102,19 @@ public class Client : IDisposable {
     }
 
     public TagPacket? GetTagPacket() {
+        var gmode = (GameMode?) (this.Metadata.ContainsKey("gameMode") ? this.Metadata["gameMode"] : null);
+        if (gmode == null) { return null; }
+        if (   gmode != GameMode.Legacy
+            && gmode != GameMode.HideAndSeek
+            && gmode != GameMode.Sardines
+        ) { return null; }
+
         var time = (Time?) (this.Metadata.ContainsKey("time")    ? this.Metadata["time"]    : null);
         var seek = (bool?) (this.Metadata.ContainsKey("seeking") ? this.Metadata["seeking"] : null);
         if (time == null && seek == null) { return null; }
+
         return new TagPacket {
+            GameMode   = (GameMode) gmode,
             UpdateType = (seek != null ? TagPacket.TagUpdate.State : 0) | (time != null ? TagPacket.TagUpdate.Time: 0),
             IsIt       = seek ?? false,
             Seconds    = (byte)   (time?.Seconds ?? 0),

--- a/Server/JsonApi/.gitignore
+++ b/Server/JsonApi/.gitignore
@@ -1,0 +1,1 @@
+/test.env

--- a/Server/JsonApi/ApiPacket.cs
+++ b/Server/JsonApi/ApiPacket.cs
@@ -1,0 +1,47 @@
+using System.Net.Sockets;
+
+using System.Text;
+using System.Text.Json;
+
+using Shared;
+
+namespace Server.JsonApi;
+
+public class ApiPacket {
+    public const ushort MAX_PACKET_SIZE = 512; // in bytes (including 20 byte header)
+
+
+    public ApiRequest? API_JSON_REQUEST { get; set; }
+
+
+    public static async Task<ApiPacket?> Read(Context ctx, string header) {
+        string reqStr = header + await ApiPacket.GetRequestStr(ctx);
+
+        ApiPacket? p = null;
+        try { p = JsonSerializer.Deserialize<ApiPacket>(reqStr); }
+        catch {
+            JsonApi.Logger.Warn($"Invalid packet deserialize from {ctx.socket.RemoteEndPoint}: {reqStr}.");
+            return null;
+        }
+
+        if (p == null) {
+            JsonApi.Logger.Warn($"Invalid packet from {ctx.socket.RemoteEndPoint}: {reqStr}.");
+            return null;
+        }
+
+        if (p.API_JSON_REQUEST == null) {
+            JsonApi.Logger.Warn($"Invalid request from {ctx.socket.RemoteEndPoint}: {reqStr}.");
+            return null;
+        }
+
+        return p;
+    }
+
+
+    private static async Task<string> GetRequestStr(Context ctx) {
+        byte[] buffer = new byte[ApiPacket.MAX_PACKET_SIZE - Constants.HeaderSize];
+        int size = await ctx.socket.ReceiveAsync(buffer, SocketFlags.None);
+        return Encoding.UTF8.GetString(buffer, 0, size);
+    }
+}
+

--- a/Server/JsonApi/ApiRequest.cs
+++ b/Server/JsonApi/ApiRequest.cs
@@ -1,0 +1,62 @@
+namespace Server.JsonApi;
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using TypesDictionary = Dictionary<string, Func<Context, Task<bool>>>;
+
+public class ApiRequest {
+    public string? Token { get; set; }
+    public string? Type { get; set; }
+    public JsonNode? Data { get; set; }
+
+
+    private static TypesDictionary Types = new TypesDictionary() {
+        ["Status"]      = async (Context ctx) => await ApiRequestStatus.Send(ctx),
+        ["Command"]     = async (Context ctx) => await ApiRequestCommand.Send(ctx),
+        ["Permissions"] = async (Context ctx) => await ApiRequestPermissions.Send(ctx),
+    };
+
+
+    public string? GetStringData() {
+        if (this.Data is JsonValue) {
+            JsonElement val = this.Data.GetValue<JsonElement>();
+            JsonValueKind kind = val.ValueKind;
+            if (kind == JsonValueKind.String) { return val.GetString(); }
+        }
+        return null;
+    }
+
+
+    public async Task<bool> Process(Context ctx) {
+        if (this.Type != null) {
+            return await ApiRequest.Types[this.Type](ctx);
+        }
+        return false;
+    }
+
+
+    public bool IsValid(Context ctx) {
+        if (this.Token == null) {
+            JsonApi.Logger.Warn($"Invalid request missing Token from {ctx.socket.RemoteEndPoint}.");
+            return false;
+        }
+
+        if (this.Type == null) {
+            JsonApi.Logger.Warn($"Invalid request missing Type from {ctx.socket.RemoteEndPoint}.");
+            return false;
+        }
+
+        if (!ApiRequest.Types.ContainsKey(this.Type)) {
+            JsonApi.Logger.Warn($"Invalid Type \"{this.Type}\" from {ctx.socket.RemoteEndPoint}.");
+            return false;
+        }
+
+        if (!Settings.Instance.JsonApi.Tokens.ContainsKey(this.Token)) {
+            JsonApi.Logger.Warn($"Invalid Token from {ctx.socket.RemoteEndPoint}.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Server/JsonApi/ApiRequestCommand.cs
+++ b/Server/JsonApi/ApiRequestCommand.cs
@@ -1,0 +1,69 @@
+namespace Server.JsonApi;
+
+public static class ApiRequestCommand {
+    public static async Task<bool> Send(Context ctx) {
+        if (!ctx.HasPermission("Commands")) {
+            await Response.Send(ctx, "Error: Missing Commands permission.");
+            return true;
+        }
+
+        if (!ApiRequestCommand.IsValid(ctx)) {
+            return false;
+        }
+
+        string input = ctx.request!.GetStringData()!;
+        string command = input.Split(" ")[0];
+
+        // help doesn't need permissions and is invidualized to the token
+        if (command == "help") {
+            List<string> commands = new List<string>();
+            commands.Add("help");
+            commands.AddRange(
+                ctx.Permissions
+                    .Where(str => str.StartsWith("Commands/"))
+                    .Select(str => str.Substring(9))
+                    .Where(cmd => CommandHandler.Handlers.ContainsKey(cmd))
+            );
+            string commandsStr = string.Join(", ", commands);
+
+            await Response.Send(ctx, $"Valid commands: {commandsStr}");
+            return true;
+        }
+
+        // no permissions
+        if (! ctx.HasPermission($"Commands/{command}")) {
+            await Response.Send(ctx, $"Error: Missing Commands/{command} permission.");
+            return true;
+        }
+
+        // execute command
+        JsonApi.Logger.Info($"[Commands] " + input);
+        await Response.Send(ctx, CommandHandler.GetResult(input));
+        return true;
+    }
+
+
+    private static bool IsValid(Context ctx) {
+        string? command = ctx.request!.GetStringData();
+
+        if (command == null) {
+            JsonApi.Logger.Warn($"[Commands] Invalid request. Data is not a \"System.String\" from {ctx.socket.RemoteEndPoint}.");
+            return false;
+        }
+
+        return true;
+    }
+
+
+    private class Response {
+        public string[]? Output { get; set; }
+
+
+        public static async Task Send(Context ctx, CommandHandler.Response response)
+        {
+            Response resp = new Response();
+            resp.Output = response.ReturnStrings;
+            await ctx.Send(resp);
+        }
+    }
+}

--- a/Server/JsonApi/ApiRequestPermissions.cs
+++ b/Server/JsonApi/ApiRequestPermissions.cs
@@ -1,0 +1,21 @@
+namespace Server.JsonApi;
+
+public static class ApiRequestPermissions {
+    public static async Task<bool> Send(Context ctx) {
+        await Response.Send(ctx);
+        return true;
+    }
+
+
+    private class Response {
+        public string[]? Permissions { get; set; }
+
+
+        public static async Task Send(Context ctx)
+        {
+            Response resp = new Response();
+            resp.Permissions = ctx.Permissions.ToArray();
+            await ctx.Send(resp);
+        }
+    }
+}

--- a/Server/JsonApi/ApiRequestStatus.cs
+++ b/Server/JsonApi/ApiRequestStatus.cs
@@ -1,0 +1,282 @@
+using Shared;
+using Shared.Packet.Packets;
+using System.Net;
+using System.Numerics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Server.JsonApi;
+
+using Mutators = Dictionary<string, Action<ApiRequestStatus.Player, Client>>;
+
+public static class ApiRequestStatus {
+    public static async Task<bool> Send(Context ctx) {
+        StatusResponse resp = new StatusResponse {
+            Settings = ApiRequestStatus.GetSettings(ctx),
+            Players  = ApiRequestStatus.Player.GetPlayers(ctx),
+        };
+        await ctx.Send(resp);
+        return true;
+    }
+
+
+    private static JsonNode? GetSettings(Context ctx)
+    {
+        // output object
+        JsonObject settings = new JsonObject();
+
+        // all permissions for Settings
+        var allowedSettings = ctx.Permissions
+            .Where(str => str.StartsWith("Status/Settings/"))
+            .Select(str => str.Substring(16))
+        ;
+
+        bool has_results = false;
+
+        // copy all allowed Settings
+        foreach (string allowedSetting in allowedSettings) {
+            string lastKey = "";
+            JsonNode? next  = settings;
+            object input = Settings.Instance;
+            JsonObject output = settings!;
+
+            // recursively go down the path
+            foreach (string key in allowedSetting.Split("/")) {
+                lastKey = key;
+
+                if (next == null) { break; }
+                output = (JsonObject) next!;
+
+                // create the sublayer
+                if (!output.ContainsKey(key)) { output.Add(key, new JsonObject()); }
+
+                // traverse down the output object
+                output.TryGetPropertyValue(key, out next);
+
+                // traverse down the Settings object
+                var prop = input.GetType().GetProperty(key);
+                if (prop == null) {
+                    JsonApi.Logger.Warn($"Property \"{allowedSetting}\" doesn't exist on the Settings object. This is probably a misconfiguration in the settings.json");
+                    goto continue2;
+                } else {
+                    input = prop.GetValue(input, null)!;
+                }
+            }
+
+            if (lastKey != "") {
+                // copy key with the actual value
+                output.Remove(lastKey);
+                output.Add(lastKey, JsonValue.Create(input));
+                has_results = true;
+            }
+
+            continue2:;
+        }
+
+        if (!has_results) { return null; }
+        return settings;
+    }
+
+
+    private class StatusResponse {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public JsonNode? Settings { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Player[]? Players  { get; set; }
+    }
+
+
+    public class Player {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Guid? ID { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Name { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public GameMode? GameMode { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Kingdom { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Stage { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? Scenario { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public PlayerPosition? Position { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public PlayerRotation? Rotation { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Tagged { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public PlayerCostume? Costume { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Capture { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Is2D { get; private set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? IPv4 { get; private set; }
+
+
+        private static Mutators Mutators = new Mutators {
+            ["Status/Players/ID"]       = (Player p, Client c) => p.ID       = c.Id,
+            ["Status/Players/Name"]     = (Player p, Client c) => p.Name     = c.Name,
+            ["Status/Players/GameMode"] = (Player p, Client c) => p.GameMode = Player.GetGameMode(c),
+            ["Status/Players/Kingdom"]  = (Player p, Client c) => p.Kingdom  = Player.GetKingdom(c),
+            ["Status/Players/Stage"]    = (Player p, Client c) => p.Stage    = Player.GetGamePacket(c)?.Stage ?? null,
+            ["Status/Players/Scenario"] = (Player p, Client c) => p.Scenario = Player.GetGamePacket(c)?.ScenarioNum ?? null,
+            ["Status/Players/Position"] = (Player p, Client c) => p.Position = PlayerPosition.FromVector3(Player.GetPlayerPacket(c)?.Position ?? null),
+            ["Status/Players/Rotation"] = (Player p, Client c) => p.Rotation = PlayerRotation.FromQuaternion(Player.GetPlayerPacket(c)?.Rotation ?? null),
+            ["Status/Players/Tagged"]   = (Player p, Client c) => p.Tagged   = Player.GetTagged(c),
+            ["Status/Players/Costume"]  = (Player p, Client c) => p.Costume  = PlayerCostume.FromClient(c),
+            ["Status/Players/Capture"]  = (Player p, Client c) => p.Capture  = Player.GetCapture(c),
+            ["Status/Players/Is2D"]     = (Player p, Client c) => p.Is2D     = Player.GetGamePacket(c)?.Is2d ?? null,
+            ["Status/Players/IPv4"]     = (Player p, Client c) => p.IPv4     = (c.Socket?.RemoteEndPoint as IPEndPoint)?.Address.ToString(),
+        };
+
+
+        public static Player[]? GetPlayers(Context ctx) {
+            if (!ctx.HasPermission("Status/Players"))  { return null; }
+            return ctx.server.ClientsConnected.Select((Client c) => Player.FromClient(ctx, c)).ToArray();
+        }
+
+
+        private static Player FromClient(Context ctx, Client c) {
+            Player player = new Player();
+            foreach (var (perm, mutate) in Mutators) {
+                if (ctx.HasPermission(perm))  {
+                    mutate(player, c);
+                }
+            }
+            return player;
+        }
+
+
+        private static GamePacket? GetGamePacket(Client c) {
+            object? lastGamePacket = null;
+            c.Metadata.TryGetValue("lastGamePacket", out lastGamePacket);
+            if (lastGamePacket == null) { return null; }
+            return (GamePacket) lastGamePacket;
+        }
+
+
+        private static PlayerPacket? GetPlayerPacket(Client c) {
+            object? lastPlayerPacket = null;
+            c.Metadata.TryGetValue("lastPlayerPacket", out lastPlayerPacket);
+            if (lastPlayerPacket == null) { return null; }
+            return (PlayerPacket) lastPlayerPacket;
+        }
+
+
+        private static GameMode? GetGameMode(Client c) {
+            object? gamemode = null;
+            c.Metadata.TryGetValue("gameMode", out gamemode);
+            return (GameMode?) gamemode;
+        }
+
+
+        private static bool? GetTagged(Client c) {
+            object? seeking = null;
+            c.Metadata.TryGetValue("seeking", out seeking);
+            return (bool?) seeking;
+        }
+
+
+        private static string? GetCapture(Client c) {
+            object? lastCapturePacket = null;
+            c.Metadata.TryGetValue("lastCapturePacket", out lastCapturePacket);
+            if (lastCapturePacket == null) { return null; }
+            CapturePacket p = (CapturePacket) lastCapturePacket;
+            if (p.ModelName == "") { return null; }
+            return p.ModelName;
+        }
+
+
+        private static string? GetKingdom(Client c) {
+            string? stage = Player.GetGamePacket(c)?.Stage ?? null;
+            if (stage == null) { return null; }
+
+            Stages.Stage2Alias.TryGetValue(stage, out string? alias);
+            if (alias == null) { return null; }
+
+            if (Stages.Alias2Kingdom.Contains(alias)) {
+                return (string?) Stages.Alias2Kingdom[alias];
+            }
+
+            return null;
+        }
+    }
+
+
+    public class PlayerCostume {
+        public string Cap  { get; private set; }
+        public string Body { get; private set; }
+
+
+        private PlayerCostume(CostumePacket p) {
+            this.Cap  = p.CapName;
+            this.Body = p.BodyName;
+        }
+
+
+        public static PlayerCostume? FromClient(Client c) {
+            if (c.CurrentCostume == null) { return null; }
+            CostumePacket p = (CostumePacket) c.CurrentCostume!;
+            return new PlayerCostume(p);
+        }
+    }
+
+
+    public class PlayerPosition {
+        public float X { get; private set; }
+        public float Y { get; private set; }
+        public float Z { get; private set; }
+
+
+        private PlayerPosition(float X, float Y, float Z) {
+            this.X = X;
+            this.Y = Y;
+            this.Z = Z;
+        }
+
+
+        public static PlayerPosition? FromVector3(Vector3? pos) {
+            if (pos == null) { return null; }
+            Vector3 p = (Vector3) pos;
+            return new PlayerPosition(p.X, p.Y, p.Z);
+        }
+    }
+
+
+    public class PlayerRotation {
+        public float W { get; private set; }
+        public float X { get; private set; }
+        public float Y { get; private set; }
+        public float Z { get; private set; }
+
+
+        private PlayerRotation(float W, float X, float Y, float Z) {
+            this.W = W;
+            this.X = X;
+            this.Y = Y;
+            this.Z = Z;
+        }
+
+
+        public static PlayerRotation? FromQuaternion(Quaternion? quat) {
+            if (quat == null) { return null; }
+            Quaternion q = (Quaternion) quat;
+            return new PlayerRotation(q.W, q.X, q.Y, q.Z);
+        }
+    }
+}

--- a/Server/JsonApi/BlockClients.cs
+++ b/Server/JsonApi/BlockClients.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Server.JsonApi;
+
+public static class BlockClients
+{
+    private const int MAX_TRIES = 5;
+
+
+    private static ConcurrentDictionary<IPAddress, int> Failures = new ConcurrentDictionary<IPAddress, int>();
+
+
+    public static bool IsBlocked(Context ctx) {
+        if (ctx.socket.RemoteEndPoint == null) { return true; }
+
+        IPAddress ip = (ctx.socket.RemoteEndPoint as IPEndPoint)!.Address;
+
+        int failures = BlockClients.Failures.GetValueOrDefault(ip, 0);
+        return failures >= BlockClients.MAX_TRIES;
+    }
+
+
+    public static void Fail(Context ctx) {
+        if (ctx.socket.RemoteEndPoint == null) { return; }
+
+        IPAddress ip = (ctx.socket.RemoteEndPoint as IPEndPoint)!.Address;
+
+        int failures = 1;
+        BlockClients.Failures.AddOrUpdate(ip, 1, (k, v) => failures = v + 1);
+
+        if (failures == BlockClients.MAX_TRIES) {
+            JsonApi.Logger.Warn($"Block client {ctx.socket.RemoteEndPoint} because of too many failed requests.");
+        }
+    }
+
+
+    public static void Redeem(Context ctx) {
+        if (ctx.socket.RemoteEndPoint == null) { return; }
+
+        IPAddress ip = (ctx.socket.RemoteEndPoint as IPEndPoint)!.Address;
+
+        BlockClients.Failures.Remove(ip, out int val);
+    }
+}

--- a/Server/JsonApi/Context.cs
+++ b/Server/JsonApi/Context.cs
@@ -1,0 +1,42 @@
+using Server;
+using Shared;
+using System.Net.Sockets;
+using System.Text.Json;
+
+namespace Server.JsonApi;
+
+public class Context {
+    public Server server;
+    public Socket socket;
+    public ApiRequest? request;
+    public Logger? logger;
+
+
+    public Context(
+        Server server,
+        Socket socket
+    ) {
+        this.server = server;
+        this.socket = socket;
+    }
+
+
+    public bool HasPermission(string perm) {
+        if (this.request == null) { return false; }
+        return Settings.Instance.JsonApi.Tokens[this.request!.Token!].Contains(perm);
+    }
+
+
+    public SortedSet<string> Permissions {
+        get {
+            if (this.request == null) { return new SortedSet<string>(); }
+            return Settings.Instance.JsonApi.Tokens[this.request!.Token!];
+        }
+    }
+
+
+    public async Task Send(object data) {
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(data);
+        await this.socket.SendAsync(bytes, SocketFlags.None);
+    }
+}

--- a/Server/JsonApi/JsonApi.cs
+++ b/Server/JsonApi/JsonApi.cs
@@ -1,0 +1,77 @@
+using System.Buffers;
+using System.Net.Sockets;
+using System.Text;
+
+using Server;
+
+using Shared;
+using Shared.Packet;
+
+namespace Server.JsonApi;
+
+
+public static class JsonApi {
+    public const ushort PACKET_TYPE = 0x5453; // ascii "ST" (0x53 0x54) from preamble, but swapped because of endianness
+    public const string PREAMBLE = "{\"API_JSON_REQUEST\":";
+
+
+    public static readonly Logger Logger = new Logger("JsonApi");
+
+
+    public static async Task<bool> HandleAPIRequest(
+        Server server,
+        Socket socket,
+        PacketHeader header,
+        IMemoryOwner<byte> memory
+    ) {
+        // check if it is enabled
+        if (!Settings.Instance.JsonApi.Enabled) {
+            return false;
+        }
+
+        // check packet type
+        if ((ushort) header.Type != JsonApi.PACKET_TYPE) {
+            server.Logger.Warn($"Accepted connection for client {socket.RemoteEndPoint}");
+            return false;
+        }
+
+        // check entire header length
+        string headerStr = Encoding.UTF8.GetString(memory.Memory.Span[..Constants.HeaderSize].ToArray());
+        if (headerStr != JsonApi.PREAMBLE) {
+            server.Logger.Warn($"Accepted connection for client {socket.RemoteEndPoint}");
+            return false;
+        }
+
+        Context ctx = new Context(server, socket);
+
+        // not if there were too many failed attempts in the past
+        if (BlockClients.IsBlocked(ctx)) {
+            JsonApi.Logger.Info($"Rejected blocked client {socket.RemoteEndPoint}.");
+            return true;
+        }
+
+        // receive & parse JSON
+        ApiPacket? p = await ApiPacket.Read(ctx, headerStr);
+        if (p == null) {
+            BlockClients.Fail(ctx);
+            return true;
+        }
+
+        // verify basic request structure & token
+        ApiRequest req = p.API_JSON_REQUEST!;
+        ctx.request = req;
+        if (!req.IsValid(ctx)) {
+            BlockClients.Fail(ctx);
+            return true;
+        }
+
+        // process request
+        if (!await req.Process(ctx)) {
+            BlockClients.Fail(ctx);
+            return true;
+        }
+
+        BlockClients.Redeem(ctx);
+        return true;
+    }
+}

--- a/Server/JsonApi/README.md
+++ b/Server/JsonApi/README.md
@@ -1,0 +1,83 @@
+The API runs on the same port as the normal game server. This is easier to deploy instead of a dedicated port, but has some limitations.
+
+To use the API the client sends only one texual JSON object to the server and might get a JSON object back (if the request is valid).
+
+The first 20 bytes of the request JSON are constant `{"API_JSON_REQUEST":`,
+to fill up and exactly match a complete normal game packet header (to identify and separate it from other server traffic).
+
+A complete request can have a size of up to 512 characters (arbitrary limit that could be increased if needed).
+
+---
+
+Every request to the server needs to be authorized by containing a secret token.
+The token and its permissions are configured in the `settings.json`.
+There can be several tokens with different permission sets.
+
+IP addresses that provide invalid requests or token values, are automatically blocked after 5 such requests until the next server restart.
+(This is mainly there to prevent agains brute force attacks that try to guess the token).
+
+---
+
+Currently available `Type` of requests:
+- `Permissions`: lists all permissions the token in use has (this request is always possible and doesn't require an extra permission).
+- `Status`: outputs all Settings, Players and Player properties the token has explicit permissions for.
+- `Command`: passes an command to the CommandHandler and returns its output. Every command needs to be permitted individually.
+
+Specific settings and commands aren't hardcoded, but the API should automatically work for future extensions on both.
+The server operator only needs to add the new permissions for the new commands or settings that they want to whitelist to the `settings.json`.
+
+The possible player status permissions are hardcoded though:
+- `Status/Players`
+- `Status/Players/ID`
+- `Status/Players/Name`
+- `Status/Players/GameMode`
+- `Status/Players/Kingdom`
+- `Status/Players/Stage`
+- `Status/Players/Scenario`
+- `Status/Players/Position`
+- `Status/Players/Rotation`
+- `Status/Players/Tagged`
+- `Status/Players/Costume`
+- `Status/Players/Capture`
+- `Status/Players/Is2D`
+- `Status/Players/IPv4`
+
+---
+
+Example for the `settings.json`:
+```json
+"JsonApi": {
+  "Enabled": true,
+  "Tokens": {
+    "SECRET_TOKEN_12345": [
+      "Status/Settings/Server/MaxPlayers",
+      "Status/Settings/Scenario/MergeEnabled",
+      "Status/Settings/Shines/Enabled",
+      "Status/Settings/PersistShines/Enabled",
+      "Status/Players",
+      "Status/Players/Name",
+      "Status/Players/Stage",
+      "Status/Players/Costume",
+      "Commands",
+      "Commands/list",
+      "Commands/sendall"
+    ]
+  }
+}
+```
+
+---
+
+Example request (e.g. with `./test.sh Command sendall mush`):
+```json
+{"API_JSON_REQUEST":{"Token":"SECRET_TOKEN_12345","Type":"Command","Data":"sendall mush"}}
+```
+
+Example `hexdump -C` response:
+```
+00000000  7b 22 4f 75 74 70 75 74  22 3a 5b 22 53 65 6e 74  |{"Output":["Sent|
+00000010  20 70 6c 61 79 65 72 73  20 74 6f 20 50 65 61 63  | players to Peac|
+00000020  68 57 6f 72 6c 64 48 6f  6d 65 53 74 61 67 65 3a  |hWorldHomeStage:|
+00000030  2d 31 22 5d 7d                                    |-1"]}|
+00000035
+```

--- a/Server/JsonApi/test.sh
+++ b/Server/JsonApi/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+TOKEN="SECRET_TOKEN_12345"
+HOST="localhost"
+PORT="1027"
+
+DIR=`dirname "$0"`
+[ -f "$DIR/test.env" ] && source "$DIR/test.env"
+
+TYPE="${1:-Status}"
+
+DATA=""
+if [ $# -gt 1 ] ; then
+  DATA=",\"Data\":\"${@:2}\""
+fi
+
+# backwards compatible way to dynamically trim binary before the first '{' character
+function trim_start () {
+  local IFS
+  local LC_ALL
+  local c
+  while IFS= LC_ALL=C read -rd '' -n1 c ; do
+    [ "$c" == "{" ] && echo -n "$c" && break
+  done
+  while IFS= LC_ALL=C read -rd '' -n1 c ; do
+    echo -n "$c"
+  done
+}
+
+echo -n "{\"API_JSON_REQUEST\":{\"Token\":\"${TOKEN}\",\"Type\":\"$TYPE\"$DATA}}"  \
+  | timeout 5.0 nc $HOST $PORT  \
+  | trim_start  \
+  | jq  \
+;
+echo ""

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -192,6 +192,12 @@ server.PacketHandler = (c, p) => {
         }
 
         case TagPacket tagPacket: {
+            if (BanLists.Enabled && BanLists.IsGameModeBanned(tagPacket.GameMode)) {
+                c.Logger.Warn($"Crashing player for entering banned gamemode {tagPacket.GameMode}.");
+                BanLists.Crash(c, 500);
+                return false;
+            }
+
             if (  (tagPacket.GameMode == GameMode.Legacy && tagPacket.UpdateType == TagPacket.TagUpdate.Both)
                 || tagPacket.GameMode == GameMode.HideAndSeek
                 || tagPacket.GameMode == GameMode.Sardines
@@ -209,6 +215,7 @@ server.PacketHandler = (c, p) => {
                 c.Metadata["time"]    = null;
             }
             c.Metadata["gameMode"] = tagPacket.GameMode;
+
             break;
         }
 

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -29,7 +29,9 @@ public class Server {
                 Socket socket = token.HasValue ? await serverSocket.AcceptAsync(token.Value) : await serverSocket.AcceptAsync();
                 socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, true);
 
-                Logger.Warn($"Accepted connection for client {socket.RemoteEndPoint}");
+                if (! Settings.Instance.JsonApi.Enabled) {
+                    Logger.Warn($"Accepted connection for client {socket.RemoteEndPoint}");
+                }
 
                 // start sub thread to handle client
                 try {
@@ -159,6 +161,8 @@ public class Server {
                     break;
                 }
                 PacketHeader header = GetHeader(memory.Memory.Span[..Constants.HeaderSize]);
+                if (first && await JsonApi.JsonApi.HandleAPIRequest(this, socket, header, memory)) { goto close; }
+
                 Range packetRange = Constants.HeaderSize..(Constants.HeaderSize + header.PacketSize);
                 if (header.PacketSize > 0) {
                     IMemoryOwner<byte> memTemp = memory; // header to copy to new memory
@@ -367,6 +371,7 @@ public class Server {
             Logger.Info($"Client {remote} disconnected from the server");
         }
 
+        close:
         bool wasConnected = client.Connected;
         client.Connected = false;
         try {

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -408,7 +408,8 @@ public class Server {
 
     private async Task SendEmptyPackets(Client client, Client other) {
         await other.Send(new TagPacket {
-            UpdateType = TagPacket.TagUpdate.State | TagPacket.TagUpdate.Time,
+            GameMode   = GameMode.Legacy,
+            UpdateType = TagPacket.TagUpdate.Both,
             IsIt       = false,
             Seconds    = 0,
             Minutes    = 0,

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -63,6 +63,7 @@ public class Settings {
         public ISet<Guid> Players { get; set; } = new SortedSet<Guid>();
         public ISet<string> IpAddresses { get; set; } = new SortedSet<string>();
         public ISet<string> Stages { get; set; } = new SortedSet<string>();
+        public ISet<sbyte> GameModes { get; set; } = new SortedSet<sbyte>();
     }
 
     public class FlipTable {

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -47,6 +47,7 @@ public class Settings {
     public DiscordTable Discord { get; set; } = new DiscordTable();
     public ShineTable Shines { get; set; } = new ShineTable();
     public PersistShinesTable PersistShines { get; set; } = new PersistShinesTable();
+    public JsonApiTable JsonApi { get; set; } = new JsonApiTable();
 
     public class ServerTable {
         public string Address { get; set; } = IPAddress.Any.ToString();
@@ -89,5 +90,11 @@ public class Settings {
     {
         public bool Enabled { get; set; } = false;
         public string Filename { get; set; } = "./moons.json";
+    }
+
+    public class JsonApiTable
+    {
+        public bool Enabled { get; set; } = false;
+        public Dictionary<string, SortedSet<string>> Tokens { get; set; } = new Dictionary<string, SortedSet<string>>();
     }
 }

--- a/Shared/Packet/Packets/TagPacket.cs
+++ b/Shared/Packet/Packets/TagPacket.cs
@@ -4,6 +4,7 @@ namespace Shared.Packet.Packets;
 
 [Packet(PacketType.Tag)]
 public struct TagPacket : IPacket {
+    public GameMode GameMode;
     public TagUpdate UpdateType;
     public bool IsIt;
     public byte Seconds;
@@ -12,22 +13,58 @@ public struct TagPacket : IPacket {
     public short Size => 5;
 
     public void Serialize(Span<byte> data) {
-        MemoryMarshal.Write(data, ref UpdateType);
+        byte both = (byte)((byte) UpdateType | ((byte) GameMode << 4));
+        MemoryMarshal.Write(data,      ref both);
         MemoryMarshal.Write(data[1..], ref IsIt);
         MemoryMarshal.Write(data[2..], ref Seconds);
         MemoryMarshal.Write(data[3..], ref Minutes);
     }
 
     public void Deserialize(ReadOnlySpan<byte> data) {
-        UpdateType = MemoryMarshal.Read<TagUpdate>(data);
-        IsIt = MemoryMarshal.Read<bool>(data[1..]);
-        Seconds = MemoryMarshal.Read<byte>(data[2..]);
-        Minutes = MemoryMarshal.Read<ushort>(data[3..]);
+        byte both  = MemoryMarshal.Read<byte>(data);
+        GameMode   = (GameMode) (sbyte) (((((both & (byte) 0xf0) >> 4) + 1) % 16) - 1);
+        UpdateType = (TagUpdate) (byte) (both & (byte) 0x0f);
+        IsIt       = MemoryMarshal.Read<bool>(data[1..]);
+        Seconds    = MemoryMarshal.Read<byte>(data[2..]);
+        Minutes    = MemoryMarshal.Read<ushort>(data[3..]);
     }
 
     [Flags]
     public enum TagUpdate : byte {
-        Time = 1,
-        State = 2
+        None      =  0,
+        Time      =  1,
+        State     =  2,
+        Both      =  3,
+        Unknown04 =  4,
+        Unknown05 =  5,
+        Unknown06 =  6,
+        Unknown07 =  7,
+        Unknown08 =  8,
+        Unknown09 =  9,
+        Unknown10 = 10,
+        Unknown11 = 11,
+        Unknown12 = 12,
+        Unknown13 = 13,
+        Unknown14 = 14,
+        All       = 15,
     }
+}
+
+public enum GameMode : sbyte {
+    None        = -1,
+    Legacy      =  0,
+    HideAndSeek =  1,
+    Sardines    =  2,
+    FreezeTag   =  3,
+    Unknown04   =  4,
+    Unknown05   =  5,
+    Unknown06   =  6,
+    Unknown07   =  7,
+    Unknown08   =  8,
+    Unknown09   =  9,
+    Unknown10   = 10,
+    Unknown11   = 11,
+    Unknown12   = 12,
+    Unknown13   = 13,
+    Reserved    = 14, // extension possibility for more future game modes with an extra added byte
 }


### PR DESCRIPTION
This PR combines #33 and #59.

The code of #33 has been [changed](https://github.com/Istador/SmoOnlineServer/commit/8aee4b45e9a370804a253e891dce30e366678c65) to be without `dynamic`.

(Combined with #59 to also include the new game mode field in the player status data of the API.)